### PR TITLE
Issue tracker and source url are implied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,7 @@
     }
   ],
   "support": {
-    "email": "pdodebug@sjoerdmaessen.nl",
-    "issues": "https://github.com/sjoerdmaessen/pdodebug/issues",
-    "source": "https://github.com/sjoerdmaessen/pdodebug"
+    "email": "pdodebug@sjoerdmaessen.nl"
   },
   "require": {
     "php": ">=5.5"


### PR DESCRIPTION
When hosting the packages on GitHub, the `support.issues` and `support.source` urls are implied by Packagist itself.